### PR TITLE
fix: toast should be disappeared after timeout and show sigin-in window when clicking like without login

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -8,8 +8,11 @@ NEXTAUTH_URL=http://localhost:3000
 
 HASURA_ADMIN_SECRET=myadminsecretkey
 
-HASH_ALGORITHM=
+HASH_ALGORITHM=HS512
+# Copy the key of `HASURA_GRAPHQL_JWT_SECRET` from `services/hasura/docker-compose.local.yaml`
 HASH_KEY=
+
+NEXT_PUBLIC_ANALYTICS_DOMAIN=http://localhost:8000
 
 # Copy the id of cypress test user, find it in your hasura data
 TEST_USER_ID=

--- a/services/hasura/seeds/default/1638093796112_table1_seed.sql
+++ b/services/hasura/seeds/default/1638093796112_table1_seed.sql
@@ -1,5 +1,5 @@
 SET check_function_bodies = false;
-INSERT INTO public."UserType" (value, comment) VALUES ('free', NULL);
+INSERT INTO public."UserType" (value, comment) VALUES ('free', 'Free user');
 INSERT INTO public."UserType" (value, comment) VALUES ('pro', 'Paid user');
 INSERT INTO public."UserType" (value, comment) VALUES ('admin', 'Site administrator');
 INSERT INTO public."UserType" (value, comment) VALUES ('anonymous', 'Anonymous widget vsisitor');

--- a/src/components/Toast/ToastItem.tsx
+++ b/src/components/Toast/ToastItem.tsx
@@ -20,9 +20,9 @@ export type ToastProps = React.PropsWithChildren<Toast> & {
 export const TOAST_DURATION = 10_000;
 
 export function ToastItem({ id, title, description, type, onDismiss }: ToastProps): JSX.Element {
-  // useTimeout(() => {
-  //   onDismiss(id);
-  // }, TOAST_DURATION);
+  useTimeout(() => {
+    onDismiss(id);
+  }, TOAST_DURATION);
 
   const typeIcon = type ? typeIconMap[type] : null;
   return (

--- a/src/hooks/useToggleALikeAction.ts
+++ b/src/hooks/useToggleALikeAction.ts
@@ -2,6 +2,7 @@ import { useToast } from '$/components/Toast';
 import { useDeleteLikeByPkMutation, useInsertOneLikeMutation } from '$/graphql/generated/like';
 
 import { useCurrentUser } from '../contexts/CurrentUserProvider/useCurrentUser';
+import { useSignInWindow } from './useSignInWindow';
 
 export type ToggleLieAction = (
   isLiked: boolean,
@@ -17,10 +18,12 @@ export function useToggleALikeAction(): ToggleLieAction {
   const [{}, deleteLikeByPk] = useDeleteLikeByPkMutation();
 
   const { showToast } = useToast();
+  const handleSignIn = useSignInWindow();
 
   const handleClickLikeAction = async (isLiked: boolean, likeId: string, commentId: string) => {
     if (!currentUserId) {
-      // throw new Error('Login first');
+      handleSignIn();
+      return;
     }
     if (isLiked) {
       const { data } = await deleteLikeByPk({


### PR DESCRIPTION
fix: toast should be disappeared after timeout and show sigin-in window when clicking like without login

## Description
<!--- Describe your changes in detail -->


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #111 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7880675/149699698-e9244bd7-d42d-4bf4-83d8-d441af785405.png)


## Checklist

- [ ] Unit tests and integration tests passed
- [ ] No reduction in test coverage
- [ ] Documentation is up to date (if appropriate)
- [x] Related issues linked using `fixes #number`
