### PR TITLE
fix: footer should be sticky to the bottom when content can't fill the viewport

### DIFF
--- a/src/blocks/Layout/LayoutWrapper.tsx
+++ b/src/blocks/Layout/LayoutWrapper.tsx
@@ -8,7 +8,7 @@ export type LayoutWrapperProps = {
 
 export function LayoutWrapper({ children, className }: LayoutWrapperProps): JSX.Element {
   return (
-    <div css={[tw`min-h-full font-sans text-gray-1000`]} className={className}>
+    <div css={[tw`min-h-full font-sans text-gray-1000 flex flex-col`]} className={className}>
       {children}
     </div>
   );

--- a/src/blocks/Layout/LayoutWrapper.tsx
+++ b/src/blocks/Layout/LayoutWrapper.tsx
@@ -8,7 +8,7 @@ export type LayoutWrapperProps = {
 
 export function LayoutWrapper({ children, className }: LayoutWrapperProps): JSX.Element {
   return (
-    <div css={[tw`min-h-full font-sans text-gray-1000 flex flex-col`]} className={className}>
+    <div css={[tw`min-h-full font-sans text-gray-1000`]} className={className}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fixs  #105
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):


## Checklist

- [ ] Unit tests and integration tests passed
- [ ] No reduction in test coverage
- [ ] Documentation is up to date (if appropriate)
- [ ] Related issues linked using `fixes #number`
