### PR TITLE
feat(docs): add bottom nav links

### DIFF
--- a/apps/main/posts/docs/self-hosted.mdx
+++ b/apps/main/posts/docs/self-hosted.mdx
@@ -85,9 +85,9 @@ You need to copy `./chirpy/*` files to Chirpy server. You can copy 2 files manua
 docker compose up -d
 ```
 
-You can visit `<your-chirpy-domain>` to check if the server is running.
+You should be able to visit `<your-chirpy-domain>` if everything works well. Happy hacking! 🎉
 
-## Add more config to Chirpy
+## Add more config to Chirpy - Optional
 
 You may find there are some unset configurations in Chirpy's `docker-compose.yml`, you can tweak them manually to suit your needs.
 

--- a/apps/main/src/pages/docs/[[...slug]].tsx
+++ b/apps/main/src/pages/docs/[[...slug]].tsx
@@ -1,11 +1,9 @@
-import { CommonPageProps, MDXProps } from '@chirpy-dev/types';
-import { SideBarProps } from '@chirpy-dev/ui';
+import { DocsProps } from '@chirpy-dev/ui';
 import { GetStaticPaths, GetStaticProps } from 'next';
 
 import { getAllFileStructures, getDirectories } from '$/server/mdx/files';
-import { getMDXPropsBySlug } from '$/server/mdx/mdx';
+import { getMDXPropsBySlug, getNearNav } from '$/server/mdx/mdx';
 
-type DocsProps = MDXProps & Pick<SideBarProps, 'directories'> & CommonPageProps;
 const CONTAINER_FOLDER = 'docs';
 
 type PathParam = {
@@ -36,15 +34,17 @@ export const getStaticProps: GetStaticProps<DocsProps, PathParam> = async ({
   if (!params?.slug) {
     return { notFound: true };
   }
-  const [mdxProps, directories] = await Promise.all([
+  const [mdxProps, directories, nearNav] = await Promise.all([
     getMDXPropsBySlug([CONTAINER_FOLDER, ...params.slug].join('/')),
     getDirectories(CONTAINER_FOLDER, `/${CONTAINER_FOLDER}`),
+    getNearNav(CONTAINER_FOLDER, params.slug.join('/')),
   ]);
 
   return {
     props: {
       ...mdxProps,
       directories,
+      nearNav,
     },
     revalidate: 3600,
   };

--- a/packages/ui/src/blocks/mdx-components/mdx-components.tsx
+++ b/packages/ui/src/blocks/mdx-components/mdx-components.tsx
@@ -27,7 +27,14 @@ interface PreProps {
 
 function Pre({ children, className, ...restProps }: PreProps): JSX.Element {
   return (
-    <pre {...restProps} className={clsx(styles.blockPre, className)}>
+    <pre
+      {...restProps}
+      className={clsx(
+        'not-prose whitespace-normal break-all',
+        styles.blockPre,
+        className,
+      )}
+    >
       {children}
     </pre>
   );

--- a/packages/ui/src/blocks/side-bar/side-bar.tsx
+++ b/packages/ui/src/blocks/side-bar/side-bar.tsx
@@ -24,7 +24,7 @@ export function SideBar({ directories, title, className }: SideBarProps) {
   const header = (
     <>
       {title && hasValidDirectories && (
-        <Heading as="h4" className="px-1 pb-4 font-bold text-gray-1100">
+        <Heading as="h4" className="px-1 pb-4 font-semibold text-gray-1100">
           {title}
         </Heading>
       )}
@@ -34,13 +34,13 @@ export function SideBar({ directories, title, className }: SideBarProps) {
     <div>
       <aside
         className={clsx(
-          'sticky top-16 isolate hidden h-[calc(100vh-4rem)] w-full flex-shrink-0 flex-col items-start px-4 sm:flex md:w-64',
+          'sticky top-16 isolate hidden h-[calc(100vh-4rem)] w-full flex-shrink-0 flex-col items-start border-r border-gray-500 pl-4 text-gray-1200 sm:flex md:w-64',
           className,
         )}
       >
         {header}
         {hasValidDirectories && (
-          <div className="w-full overflow-y-auto">
+          <div className="w-full overflow-y-auto pr-1">
             <Directories directories={directories} />
           </div>
         )}
@@ -85,8 +85,9 @@ function Directories({
 
 function DirectoryItem({ directory: dir }: { directory: Directory }) {
   const router = useRouter();
-  const [isOpened, setIsOpened] = React.useState(false);
-  const isActive = isButtonActive(dir, router.asPath);
+  const [isOpened, setIsOpened] = React.useState(() =>
+    isButtonActive(dir, router.asPath),
+  );
   const listMarker = dir.route ? (
     <span className="mr-3.5 inline-block h-1.5 w-1.5 rounded-full bg-current hover:bg-gray-1200" />
   ) : (
@@ -99,6 +100,7 @@ function DirectoryItem({ directory: dir }: { directory: Directory }) {
       }}
     />
   );
+
   return (
     <>
       {dir.route ? (
@@ -117,11 +119,7 @@ function DirectoryItem({ directory: dir }: { directory: Directory }) {
         </Link>
       ) : (
         <button
-          className={clsx(
-            `capitalize text-gray-1100`,
-            clickableItemStyle,
-            isActive && activeStyle,
-          )}
+          className={clsx(`capitalize`, clickableItemStyle)}
           type="button"
           onClick={() => setIsOpened((prev) => !prev)}
           aria-label="Expand children routes"
@@ -141,10 +139,10 @@ function DirectoryItem({ directory: dir }: { directory: Directory }) {
 }
 
 const clickableItemStyle = [
-  `transition flex flex-row items-center justify-start`,
+  `flex flex-row items-center justify-start`,
   listHoverable,
 ];
-const activeStyle = `text-gray-1200 font-bold`;
+const activeStyle = `bg-primary-500 border border-primary-700 text-primary-1100`;
 
 function isButtonActive(dir: Directory, pathname: string) {
   if (dir.route === pathname) {

--- a/packages/ui/src/components/link/link.tsx
+++ b/packages/ui/src/components/link/link.tsx
@@ -93,7 +93,11 @@ export const Link = React.forwardRef(function Link(
       {variant === 'plain' ? (
         <a
           {...commonProps}
-          className={clsx(disabled && disabledStyle, className)}
+          className={clsx(
+            size && sizeStyles[size],
+            disabled && disabledStyle,
+            className,
+          )}
           onClick={handler}
           ref={ref}
         >

--- a/packages/ui/src/pages/docs/index.tsx
+++ b/packages/ui/src/pages/docs/index.tsx
@@ -1,4 +1,5 @@
 import { CommonPageProps, MDXProps } from '@chirpy-dev/types';
+import clsx from 'clsx';
 import { MDXRemote } from 'next-mdx-remote';
 
 import {
@@ -8,13 +9,28 @@ import {
   SideBar,
   SideBarProps,
 } from '../../blocks';
+import { IconChevronRight, Link } from '../../components';
+import { listHoverable } from '../../styles/common';
 
-type DocsProps = MDXProps & Pick<SideBarProps, 'directories'> & CommonPageProps;
+export type DocNav = {
+  title: string;
+  link: string;
+};
+
+export type NearNav = {
+  prev?: DocNav;
+  next?: DocNav;
+};
+
+export type DocsProps = MDXProps &
+  Pick<SideBarProps, 'directories'> &
+  CommonPageProps & { nearNav: NearNav };
 
 export function Docs({
   mdxSource,
   frontMatter,
   directories = [],
+  nearNav,
 }: DocsProps): JSX.Element {
   return (
     <SiteLayout
@@ -22,7 +38,7 @@ export function Docs({
       hideFullBleed
       hideFooter
       styles={{
-        container: 'py-0',
+        container: 'py-0 md:mx-0',
       }}
     >
       <div className="flex min-h-full flex-col">
@@ -30,7 +46,7 @@ export function Docs({
           <SideBar
             className="pt-10"
             directories={directories}
-            title="Documentation"
+            title="Document"
           />
           <div className="flex-1">
             <article className="prose mx-auto overflow-x-hidden pt-10">
@@ -38,6 +54,41 @@ export function Docs({
                 <MDXRemote {...mdxSource} components={MDXComponents} />
               )}
             </article>
+            <section className="mt-10">
+              <div className="mx-auto flex max-w-[65ch] flex-row justify-between">
+                {nearNav.prev ? (
+                  <Link
+                    size="lg"
+                    variant="plain"
+                    href={nearNav.prev.link}
+                    className={clsx(
+                      'flex -translate-x-5 flex-row items-center px-3 py-2 text-gray-1200',
+                      listHoverable,
+                    )}
+                  >
+                    <IconChevronRight size={28} className="rotate-180" />
+                    <span>{nearNav.prev.title}</span>
+                  </Link>
+                ) : (
+                  // To fill left empty when there is only 1 next
+                  <div />
+                )}
+                {nearNav.next && (
+                  <Link
+                    size="lg"
+                    variant="plain"
+                    href={nearNav.next.link}
+                    className={clsx(
+                      'flex translate-x-5 flex-row items-center px-3 py-2 text-gray-1200',
+                      listHoverable,
+                    )}
+                  >
+                    <span>{nearNav.next.title}</span>
+                    <IconChevronRight size={28} className="" />
+                  </Link>
+                )}
+              </div>
+            </section>
             <Footer />
           </div>
         </section>

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,2 +1,9 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = require('configs').tailwindConfig;
+module.exports = {
+  ...require('configs').tailwindConfig,
+  content: [
+    './src/**/*.{ts,tsx}',
+    './.storybook/**/*.{ts,tsx}',
+    './node_modules/@chirpy-dev/ui/src/**/*.{ts,tsx}',
+  ],
+};


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Also fixes the broken `/docs/index`, as it may be conflicted with Vercel route system.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/7880675/198837227-40fe94a6-e541-4764-8cf0-36a42f4f60d7.png">


## Checklist

- [ ] Unit tests and integration tests passed
- [ ] No reduction in test coverage
- [ ] Documentation is up to date (if appropriate)
- [ ] Related issues linked using `fixes #number`
