### PR TITLE
fix(comment-preview): can't post a comment and don't query notification messages if user doesn't signin

### DIFF
--- a/apps/main/src/middleware.ts
+++ b/apps/main/src/middleware.ts
@@ -18,6 +18,10 @@ export const config = {
     '/analytics/:path*',
     '/profile/:path*',
     '/theme/:path*',
-    '/api/content-classifier/toxic-text',
+
+    // Don't add /api/content-classifier/toxic-text here,
+    // it's used by the comment-widget-preview,
+    // so it should be public
+    // '/api/content-classifier/toxic-text',
   ],
 };

--- a/packages/ui/.vscode/launch.json
+++ b/packages/ui/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests.v2",
+      "request": "launch",
+      "args": [
+        "--inspect",
+        "${workspaceRoot}/node_modules/jest/bin/jest.js",
+        "--runInBand",
+        "--watchAll=false",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    }
+  ]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -81,6 +81,7 @@
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
     "@types/react-flatpickr": "3.8.8",
+    "@types/testing-library__jest-dom": "5.14.5",
     "autoprefixer": "10.4.13",
     "babel-loader": "8.2.5",
     "chromatic": "6.11.4",

--- a/packages/ui/public/tailwind.css
+++ b/packages/ui/public/tailwind.css
@@ -3142,6 +3142,10 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.text-white\/90 {
+  color: rgb(255 255 255 / 0.9);
+}
+
 .text-whitea-1200 {
   color: hsla(var(--tw-colors-whitea-1200));
 }
@@ -3531,6 +3535,11 @@ video {
 .hover\:bg-gray-1200:hover {
   --tw-bg-opacity: 1;
   background-color: hsl(var(--tw-colors-gray-1200) / var(--tw-bg-opacity));
+}
+
+.hover\:bg-primary-800:hover {
+  --tw-bg-opacity: 1;
+  background-color: hsl(var(--tw-colors-primary-800) / var(--tw-bg-opacity));
 }
 
 .hover\:bg-primary-1000:hover {
@@ -4222,6 +4231,10 @@ video {
     flex-direction: column;
   }
 
+  .sm\:items-center {
+    align-items: center;
+  }
+
   .sm\:items-stretch {
     align-items: stretch;
   }
@@ -4256,6 +4269,12 @@ video {
     --tw-space-x-reverse: 0;
     margin-right: calc(0.75rem * var(--tw-space-x-reverse));
     margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(0.25rem * var(--tw-space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
@@ -4331,6 +4350,10 @@ video {
 
   .sm\:pl-6 {
     padding-left: 1.5rem;
+  }
+
+  .sm\:pl-0 {
+    padding-left: 0px;
   }
 
   .sm\:pt-6 {
@@ -4841,4 +4864,8 @@ video {
 
 .\[\&\:\:-moz-color-swatch-wrapper\]\:p-0::-moz-color-swatch-wrapper {
   padding: 0px;
+}
+
+.\[\&_a\]\:underline a {
+  text-decoration-line: underline;
 }

--- a/packages/ui/src/__tests__/fixtures/page-render.tsx
+++ b/packages/ui/src/__tests__/fixtures/page-render.tsx
@@ -4,15 +4,7 @@ import { ToastProvider } from '../../components';
 // import '../mocks/next-router';
 import { CurrentUserContext, UserData } from '../../contexts';
 import { trpcClient } from '../../utilities';
-import { mockUserData } from '../mocks/data/user';
-
-export const mockRefetchUser = jest.fn();
-const DEFAULT_USER_DATA = {
-  data: mockUserData,
-  isSignIn: true,
-  loading: false,
-  refetchUser: mockRefetchUser,
-};
+import { DEFAULT_USER_DATA } from '../mocks/data/user';
 
 const getMockedUser = jest.fn().mockReturnValue(DEFAULT_USER_DATA);
 

--- a/packages/ui/src/__tests__/jest.setup.ts
+++ b/packages/ui/src/__tests__/jest.setup.ts
@@ -26,7 +26,3 @@ jest.mock('next/dynamic', () => (func: () => Promise<any>) => {
   DynamicComponent.preload = jest.fn();
   return DynamicComponent;
 });
-
-jest.mock('rehype-pretty-code', () => () => null);
-jest.mock('rehype-autolink-headings', () => () => null);
-jest.mock('rehype-slug', () => () => null);

--- a/packages/ui/src/__tests__/mocks/data/user.ts
+++ b/packages/ui/src/__tests__/mocks/data/user.ts
@@ -26,3 +26,12 @@ export const mockUserData = {
   ],
   editableProjectIds: EDITABLE_PROJECT_IDS,
 };
+
+export const mockRefetchUser = jest.fn();
+
+export const DEFAULT_USER_DATA = {
+  data: mockUserData,
+  isSignIn: true,
+  loading: false,
+  refetchUser: mockRefetchUser,
+};

--- a/packages/ui/src/blocks/analytics/lazy-loader.tsx
+++ b/packages/ui/src/blocks/analytics/lazy-loader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
 interface LazyLoaderProps {
   onVisible?: () => void;
@@ -7,15 +7,20 @@ interface LazyLoaderProps {
   style?: React.CSSProperties;
 }
 
-export default class LazyLoader extends React.Component<LazyLoaderProps> {
-  observer: IntersectionObserver;
-  element: HTMLElement;
-  componentDidMount() {
-    this.observer = new IntersectionObserver(
+function LazyLoader(props: LazyLoaderProps): JSX.Element {
+  const element = useRef<HTMLDivElement>(null);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const elm = element.current;
+    if (!elm) {
+      return;
+    }
+    observer.current = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
-          this.props.onVisible && this.props.onVisible();
-          this.observer.unobserve(this.element);
+          props.onVisible && props.onVisible();
+          observer.current?.unobserve(elm);
         }
       },
       {
@@ -23,24 +28,18 @@ export default class LazyLoader extends React.Component<LazyLoaderProps> {
       },
     );
 
-    this.observer.observe(this.element);
-  }
+    observer.current.observe(element.current);
 
-  componentWillUnmount() {
-    this.observer.unobserve(this.element);
-  }
+    return () => {
+      observer.current?.unobserve(elm);
+    };
+  }, []);
 
-  render() {
-    return (
-      <div
-        ref={(el) => {
-          this.element = el!;
-        }}
-        className={this.props.className}
-        style={this.props.style}
-      >
-        {this.props.children}
-      </div>
-    );
-  }
+  return (
+    <div ref={element} className={props.className} style={props.style}>
+      {props.children}
+    </div>
+  );
 }
+
+export default LazyLoader;

--- a/packages/ui/src/blocks/analytics/lazy-loader.tsx
+++ b/packages/ui/src/blocks/analytics/lazy-loader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, MutableRefObject } from 'react';
 
 interface LazyLoaderProps {
   onVisible?: () => void;
@@ -7,39 +7,38 @@ interface LazyLoaderProps {
   style?: React.CSSProperties;
 }
 
-function LazyLoader(props: LazyLoaderProps): JSX.Element {
-  const element = useRef<HTMLDivElement>(null);
-  const observer = useRef<IntersectionObserver | null>(null);
+export default React.forwardRef<HTMLDivElement, LazyLoaderProps>(
+  function LazyLoader(props, ref): JSX.Element {
+    const observer = useRef<IntersectionObserver | null>(null);
 
-  useEffect(() => {
-    const elm = element.current;
-    if (!elm) {
-      return;
-    }
-    observer.current = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          props.onVisible && props.onVisible();
-          observer.current?.unobserve(elm);
-        }
-      },
-      {
-        threshold: 0,
-      },
+    useEffect(() => {
+      const elm = (ref as MutableRefObject<HTMLDivElement>)?.current;
+      if (!elm) {
+        return;
+      }
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            props.onVisible && props.onVisible();
+            observer.current?.unobserve(elm);
+          }
+        },
+        {
+          threshold: 0,
+        },
+      );
+
+      observer.current.observe(elm);
+
+      return () => {
+        observer.current?.unobserve(elm);
+      };
+    }, []);
+
+    return (
+      <div ref={ref} className={props.className} style={props.style}>
+        {props.children}
+      </div>
     );
-
-    observer.current.observe(element.current);
-
-    return () => {
-      observer.current?.unobserve(elm);
-    };
-  }, []);
-
-  return (
-    <div ref={element} className={props.className} style={props.style}>
-      {props.children}
-    </div>
-  );
-}
-
-export default LazyLoader;
+  },
+);

--- a/packages/ui/src/blocks/analytics/stats/modals/modal.tsx
+++ b/packages/ui/src/blocks/analytics/stats/modals/modal.tsx
@@ -63,6 +63,12 @@ function Modal({ router, site, onClick, maxWidth, children }: ModalProps) {
     router.push(`/${encodeURIComponent(site.domain)}${location.search}`);
   }
 
+  /**
+   * Decide whether to set max-width, and if so, to what.
+   * If no max-width is available, set width instead to min-content such that we can rely on widths set on th.
+   * On >md, we use the same behaviour as before: set width to 800 pixels.
+   * Note that When a max-width comes from the parent component, we rely on that *always*.
+   */
   function getStyle() {
     const styleObject: any = {};
     if (maxWidth) {

--- a/packages/ui/src/blocks/analytics/stats/modals/modal.tsx
+++ b/packages/ui/src/blocks/analytics/stats/modals/modal.tsx
@@ -17,72 +17,53 @@ interface ModalProps {
   maxWidth: number;
 }
 
-interface ModalState {
-  viewport: number;
-}
+function Modal({ router, site, onClick, maxWidth, children }: ModalProps) {
+  const [viewport, setViewport] = useState(DEFAULT_WIDTH);
+  const node = useRef(null);
 
-class Modal extends React.Component<ModalProps, ModalState> {
-  node: React.RefObject<HTMLDivElement> = React.createRef();
-  state = {
-    viewport: DEFAULT_WIDTH,
-  };
-
-  componentDidMount() {
+  useEffect(() => {
     document.body.style.overflow = 'hidden';
     document.body.style.height = '100vh';
 
-    document.addEventListener('mousedown', this.handleClickOutside);
-    document.addEventListener('keyup', this.handleKeyup);
-    window.addEventListener('resize', this.handleResize, false);
-    this.handleResize();
-  }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keyup', handleKeyup);
+    window.addEventListener('resize', handleResize, false);
+    handleResize();
 
-  componentWillUnmount() {
-    document.body.style.removeProperty('overflow');
-    document.body.style.removeProperty('height');
+    return () => {
+      document.body.style.removeProperty('overflow');
+      document.body.style.removeProperty('height');
 
-    document.removeEventListener('mousedown', this.handleClickOutside);
-    document.removeEventListener('keyup', this.handleKeyup);
-    window.removeEventListener('resize', this.handleResize, false);
-  }
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keyup', handleKeyup);
+      window.removeEventListener('resize', handleResize, false);
+    };
+  }, []);
 
-  handleClickOutside = (e: MouseEvent) => {
+  function handleClickOutside(e: MouseEvent) {
     // @ts-ignore
-    if (this.node.current?.contains(e.target)) {
+    if (node.current?.contains(e.target)) {
       return;
     }
 
-    this.close();
-  };
-
-  handleKeyup = (e: KeyboardEvent) => {
-    if (e.code === 'Escape') {
-      this.close();
-    }
-  };
-
-  handleResize = () => {
-    this.setState({ viewport: window.innerWidth });
-  };
-
-  close() {
-    this.props.router.push(
-      `/${encodeURIComponent(this.props.site.domain)}${
-        this.props.location.search
-      }`,
-    );
+    close();
   }
 
-  /**
-   * @description
-   * Decide whether to set max-width, and if so, to what.
-   * If no max-width is available, set width instead to min-content such that we can rely on widths set on th.
-   * On >md, we use the same behaviour as before: set width to 800 pixels.
-   * Note that When a max-width comes from the parent component, we rely on that *always*.
-   */
-  getStyle() {
-    const { maxWidth } = this.props;
-    const { viewport } = this.state;
+  function handleKeyup(e: KeyboardEvent) {
+    if (e.code === 'Escape') {
+      close();
+    }
+  }
+
+  function handleResize() {
+    setViewport(window.innerWidth);
+  }
+
+  function close() {
+    router.push(`/${encodeURIComponent(site.domain)}${location.search}`);
+  }
+
+  function getStyle() {
     const styleObject: any = {};
     if (maxWidth) {
       styleObject.maxWidth = maxWidth;
@@ -92,23 +73,21 @@ class Modal extends React.Component<ModalProps, ModalState> {
     return styleObject;
   }
 
-  render() {
-    return createPortal(
-      <div className="modal is-open" onClick={this.props.onClick}>
-        <div className="modal__overlay">
-          <button className="modal__close"></button>
-          <div
-            ref={this.node}
-            className="modal__container dark:bg-gray-800"
-            style={this.getStyle()}
-          >
-            {this.props.children}
-          </div>
+  return createPortal(
+    <div className="modal is-open" onClick={onClick}>
+      <div className="modal__overlay">
+        <button className="modal__close"></button>
+        <div
+          ref={node}
+          className="modal__container dark:bg-gray-800"
+          style={getStyle()}
+        >
+          {children}
         </div>
-      </div>,
-      document.querySelector('#modal_root')!,
-    );
-  }
+      </div>
+    </div>,
+    document.querySelector('#modal_root')!,
+  );
 }
 
 export default Modal;

--- a/packages/ui/src/blocks/comment-card/timeline-link-button.tsx
+++ b/packages/ui/src/blocks/comment-card/timeline-link-button.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ActionButton, ButtonProps } from '../../components/button';
 import { IconInfo } from '../../components/icons';
+import { useCurrentUser } from '../../contexts';
 import { useCommentContext } from '../../contexts/comment-context';
 
 type TimelineLinkButtonProps = {
@@ -13,8 +14,9 @@ export function TimelineLinkButton({
   href,
   onClick,
 }: TimelineLinkButtonProps): JSX.Element {
-  const { onClickCommentTimeline, hideCommentTimeline } = useCommentContext();
-  if (hideCommentTimeline) {
+  const { isPreview } = useCurrentUser();
+  const { onClickCommentTimeline } = useCommentContext();
+  if (isPreview) {
     return <></>;
   }
   return (

--- a/packages/ui/src/blocks/comment-widget-preview/comment-widget-preview.tsx
+++ b/packages/ui/src/blocks/comment-widget-preview/comment-widget-preview.tsx
@@ -17,8 +17,7 @@ import { PredefinedCurrentUser } from './predefined-current-user';
 import { PredefinedNotification } from './predefined-notification';
 import { getPreviewComments, PAGE_ID, PROJECT_ID } from './preview-data';
 
-export interface CommentWidgetPreviewProps
-  extends Pick<CommentContextType, 'hideCommentTimeline'> {
+export interface CommentWidgetPreviewProps {
   rtePlaceholder?: string;
   buildDate: string;
 }
@@ -122,15 +121,8 @@ function CommentWidgetPreviewInternal(
       deleteAComment,
       toggleALikeAction,
       onClickCommentTimeline,
-      ...(props.hideCommentTimeline && { hideCommentTimeline: true }),
     }),
-    [
-      createAComment,
-      deleteAComment,
-      toggleALikeAction,
-      onClickCommentTimeline,
-      props.hideCommentTimeline,
-    ],
+    [createAComment, deleteAComment, toggleALikeAction, onClickCommentTimeline],
   );
   return (
     <CommentContext.Provider value={commentContext}>

--- a/packages/ui/src/blocks/comment-widget-preview/home-comment-widget-preview.tsx
+++ b/packages/ui/src/blocks/comment-widget-preview/home-comment-widget-preview.tsx
@@ -24,7 +24,6 @@ export function HomeCommentWidgetPreview({
       </div>
       <div className="w-full rounded-lg border border-gray-300 bg-gray-0 p-4">
         <CommentWidgetPreview
-          hideCommentTimeline
           rtePlaceholder="Comment widget (Markdown supported)"
           buildDate={buildDate}
         />

--- a/packages/ui/src/blocks/comment-widget-preview/predefined-current-user.tsx
+++ b/packages/ui/src/blocks/comment-widget-preview/predefined-current-user.tsx
@@ -20,6 +20,7 @@ export function PredefinedCurrentUser(
     () => ({
       loading: false,
       isSignIn: true,
+      isPreview: true,
       data: {
         editableProjectIds: [],
         id: 'ffad5f9c-0c28-4c9b-a652-b21a2a42949b',

--- a/packages/ui/src/blocks/notification-hub/__tests__/notification-hub.test.tsx
+++ b/packages/ui/src/blocks/notification-hub/__tests__/notification-hub.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { pageRender } from '../../../__tests__/fixtures/page-render';
@@ -12,6 +12,7 @@ import { NotificationHub } from '../notification-hub';
 describe('NotificationHub', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    cleanup();
   });
 
   it('should render the messages', async () => {
@@ -23,6 +24,7 @@ describe('NotificationHub', () => {
     await renderDefaultNotificationHub();
 
     await userEvent.click(screen.getAllByAltText(/avatar/)[0]);
+
     expect(mockReadNotification).toHaveBeenCalledTimes(1);
   });
 
@@ -39,6 +41,8 @@ async function renderDefaultNotificationHub() {
   const notificationButton = screen.getByLabelText('click to open the menu');
   await userEvent.click(notificationButton);
   await waitFor(() => {
-    expect(screen.getAllByLabelText('Delete the message')[0]).toBeDefined();
+    expect(
+      screen.getAllByLabelText('Delete the message')[0],
+    ).toBeInTheDocument();
   });
 }

--- a/packages/ui/src/blocks/notification-hub/notification-hub.tsx
+++ b/packages/ui/src/blocks/notification-hub/notification-hub.tsx
@@ -56,13 +56,14 @@ export function NotificationHub(): JSX.Element {
                   index={index}
                   length={data.length}
                   onClickCapture={async (messageId) => {
-                    if (!!!process.env.NEXT_PUBLIC_MAINTENANCE_MODE) {
+                    if (!!process.env.NEXT_PUBLIC_MAINTENANCE_MODE) {
                       return;
                     }
                     await readANotification({ messageId });
                     await refechMessages();
                   }}
                   onClickDelete={async (messageId) => {
+                    console.log('Clicking delete');
                     await deleteNotificationMessage({ messageId });
                     refechMessages();
                   }}

--- a/packages/ui/src/blocks/notification-hub/notification-hub.tsx
+++ b/packages/ui/src/blocks/notification-hub/notification-hub.tsx
@@ -63,7 +63,6 @@ export function NotificationHub(): JSX.Element {
                     await refechMessages();
                   }}
                   onClickDelete={async (messageId) => {
-                    console.log('Clicking delete');
                     await deleteNotificationMessage({ messageId });
                     refechMessages();
                   }}

--- a/packages/ui/src/blocks/notification-hub/notification-hub.tsx
+++ b/packages/ui/src/blocks/notification-hub/notification-hub.tsx
@@ -12,13 +12,13 @@ import styles from './notification-hub.module.scss';
 import { NotificationItem } from './notification-item';
 
 export function NotificationHub(): JSX.Element {
-  const { isSignIn } = useCurrentUser();
+  const { isSignIn, isPreview } = useCurrentUser();
   const {
     data,
     refetch: refechMessages,
     isFetching,
   } = trpcClient.notification.messages.useQuery(undefined, {
-    enabled: !!isSignIn,
+    enabled: !!isSignIn && !isPreview,
   });
 
   const { mutateAsync: readANotification } =

--- a/packages/ui/src/components/popover/popover-panel.tsx
+++ b/packages/ui/src/components/popover/popover-panel.tsx
@@ -8,7 +8,6 @@ type ButtonDimension = { height?: number; width?: number };
 export type Placement = 'top' | 'topEnd' | 'bottomEnd';
 
 export interface IPopoverPanelProps {
-  buttonAs?: React.ElementType<Record<string, unknown>>;
   /**
    * TODO
    */

--- a/packages/ui/src/contexts/comment-context/comment-context.ts
+++ b/packages/ui/src/contexts/comment-context/comment-context.ts
@@ -13,7 +13,6 @@ export type CommentContextType = {
   deleteAComment: UseDeleteAComment;
   toggleALikeAction: UseToggleALikeAction;
   onClickCommentTimeline: (href: string) => void;
-  hideCommentTimeline?: true;
 };
 
 export const CommentContext = React.createContext<CommentContextType>({

--- a/packages/ui/src/contexts/current-user-context/current-user-context.ts
+++ b/packages/ui/src/contexts/current-user-context/current-user-context.ts
@@ -7,10 +7,17 @@ import { trpcClient } from '../../utilities/trpc-client';
 
 export type UserData = Nullable<Session['user']>;
 
+export type RefetchUser = ReturnType<
+  typeof trpcClient.user.me.useQuery
+>['refetch'];
+
 export type CurrentUserContextType = {
-  refetchUser: ReturnType<typeof trpcClient.user.me.useQuery>['refetch'];
+  refetchUser: RefetchUser;
   loading: boolean;
   isSignIn: boolean;
+  // We have a preview widget in home page,
+  // we need to turn off some features if we are in preview mode
+  isPreview?: true;
   data: UserData & {
     editableProjectIds?: string[];
   };
@@ -19,9 +26,8 @@ export type CurrentUserContextType = {
 export const EMPTY_CURRENT_USER_CONTEXT: CurrentUserContextType = {
   isSignIn: false,
   data: {},
-  loading: true,
-  // @ts-ignore
-  refetchUser: asyncNoop,
+  loading: false,
+  refetchUser: asyncNoop as unknown as RefetchUser,
 };
 
 export const CurrentUserContext = React.createContext<CurrentUserContextType>(

--- a/packages/ui/src/contexts/current-user-context/use-current-user.ts
+++ b/packages/ui/src/contexts/current-user-context/use-current-user.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {
   CurrentUserContext,
   CurrentUserContextType,
-} from '../../contexts/current-user-context/current-user-context';
+} from './current-user-context';
 
 export function useCurrentUser(): CurrentUserContextType {
   const context = React.useContext(CurrentUserContext);

--- a/packages/ui/src/pages/dashboard/create-project-button.tsx
+++ b/packages/ui/src/pages/dashboard/create-project-button.tsx
@@ -1,0 +1,96 @@
+import { isENVProd } from '@chirpy-dev/utils';
+import * as React from 'react';
+
+import {
+  Button,
+  Heading,
+  IconPlusCircle,
+  Popover,
+  Text,
+} from '../../components';
+import { useCurrentUser } from '../../contexts';
+
+export type CreateProjectButtonProps = {
+  projectCount?: number;
+  onCreateProject: () => void;
+};
+
+export function CreateProjectButton(
+  props: CreateProjectButtonProps,
+): JSX.Element {
+  const { data } = useCurrentUser();
+  // let disabledType: DisabledType | undefined = 'maintenanceMode';
+  let disabledType: DisabledType | undefined;
+  if (isENVProd && (props.projectCount || 0) > 0) {
+    disabledType = 'projectLimit';
+  } else if (!data.email) {
+    disabledType = 'anonymous';
+  } else if (process.env.NEXT_PUBLIC_MAINTENANCE_MODE) {
+    disabledType = 'maintenanceMode';
+  }
+  const createButtonProps = {
+    variant: 'solid',
+    color: 'primary',
+    className: 'space-x-1',
+  } as const;
+  const createButtonChildren = (
+    <>
+      <IconPlusCircle size={18} />
+      <span>Create project</span>
+    </>
+  );
+  return (
+    <>
+      {disabledType ? (
+        <Popover>
+          <Popover.Button {...createButtonProps}>
+            {createButtonChildren}
+          </Popover.Button>
+          <Popover.Panel type="alert" placement="bottomEnd">
+            {DISABLED_MESSAGE_MAP[disabledType]}
+          </Popover.Panel>
+        </Popover>
+      ) : (
+        <Button onClick={props.onCreateProject} {...createButtonProps}>
+          {createButtonChildren}
+        </Button>
+      )}
+    </>
+  );
+}
+
+type DisabledType = 'anonymous' | 'projectLimit' | 'maintenanceMode';
+const DISABLED_MESSAGE_MAP: Record<DisabledType, JSX.Element> = {
+  anonymous: (
+    <section className="w-[24rem]">
+      <Heading as="h5" className="font-bold">
+        Connect an email with your account
+      </Heading>
+      <Text className="mt-2" variant="secondary">
+        Otherwise, you may lose access to your project after creation. You can
+        re-sign in with your email or social media account.
+      </Text>
+    </section>
+  ),
+  projectLimit: (
+    <section className="w-[24rem]">
+      <Heading as="h5" className="font-bold">
+        Reached the maximum number of projects
+      </Heading>
+      <Text className="mt-2" variant="secondary">
+        You can delete an existing project to create a new one.
+      </Text>
+    </section>
+  ),
+  maintenanceMode: (
+    <section className="w-[24rem]">
+      <Heading as="h5" className="font-bold">
+        System maintenance mode
+      </Heading>
+      <Text className="mt-2" variant="secondary">
+        All editing actions are disabled during this period, Please check back
+        in a little while and try again.
+      </Text>
+    </section>
+  ),
+};

--- a/packages/ui/src/pages/dashboard/index.tsx
+++ b/packages/ui/src/pages/dashboard/index.tsx
@@ -15,11 +15,13 @@ import {
   Spinner,
   TextField,
   Text,
+  Heading,
 } from '../../components';
 import { useCurrentUser } from '../../contexts';
 import { useForm } from '../../hooks';
 import { isValidDomain } from '../../utilities';
 import { trpcClient } from '../../utilities/trpc-client';
+import { CreateProjectButton } from './create-project-button';
 
 type FormFields = {
   name: string;
@@ -71,41 +73,16 @@ export function Dashboard(): JSX.Element {
       fetchUserProjects();
     },
   );
-  const disableCreation = isENVProd && (projects?.length || 0) > 0;
-  const isAnonymousUser = !!data.email;
 
   return (
     <SiteLayout title="Dashboard">
       <section className="space-y-10">
         <div className="flex flex-col items-start space-y-5 sm:flex-row sm:justify-between sm:space-x-2 sm:space-y-0">
           <PageTitle>Dashboard</PageTitle>
-          <Popover>
-            <Popover.Button
-              onClick={handleCreateProject}
-              variant="solid"
-              color="primary"
-              className="space-x-1"
-              disabled={
-                disableCreation || !!process.env.NEXT_PUBLIC_MAINTENANCE_MODE
-              }
-            >
-              <IconPlusCircle size={18} />
-              <span>Create project</span>
-            </Popover.Button>
-            <Popover.Panel>
-              {isAnonymousUser && (
-                <div>
-                  <Text>
-                    Sorry, you need an email with your account to create a
-                    project. Otherwise, you may lose access to your project.
-                  </Text>
-                  <Text>
-                    You can re-sign in with your email or social media account
-                  </Text>
-                </div>
-              )}
-            </Popover.Panel>
-          </Popover>
+          <CreateProjectButton
+            projectCount={projects?.length}
+            onCreateProject={handleCreateProject}
+          />
         </div>
         {projects?.length ? (
           <div className="flex flex-row">

--- a/packages/ui/src/pages/dashboard/index.tsx
+++ b/packages/ui/src/pages/dashboard/index.tsx
@@ -11,8 +11,10 @@ import {
   Button,
   Dialog,
   IconPlusCircle,
+  Popover,
   Spinner,
   TextField,
+  Text,
 } from '../../components';
 import { useCurrentUser } from '../../contexts';
 import { useForm } from '../../hooks';
@@ -25,7 +27,7 @@ type FormFields = {
 };
 
 export function Dashboard(): JSX.Element {
-  const { loading: userIsLoading } = useCurrentUser();
+  const { loading: userIsLoading, data } = useCurrentUser();
   const {
     data: projects,
     refetch: fetchUserProjects,
@@ -70,28 +72,44 @@ export function Dashboard(): JSX.Element {
     },
   );
   const disableCreation = isENVProd && (projects?.length || 0) > 0;
+  const isAnonymousUser = !!data.email;
 
   return (
     <SiteLayout title="Dashboard">
       <section className="space-y-10">
         <div className="flex flex-col items-start space-y-5 sm:flex-row sm:justify-between sm:space-x-2 sm:space-y-0">
           <PageTitle>Dashboard</PageTitle>
-          <Button
-            onClick={handleCreateProject}
-            variant="solid"
-            color="primary"
-            className="space-x-1"
-            disabled={
-              disableCreation || !!process.env.NEXT_PUBLIC_MAINTENANCE_MODE
-            }
-          >
-            <IconPlusCircle size={18} />
-            <span>Create project</span>
-          </Button>
+          <Popover>
+            <Popover.Button
+              onClick={handleCreateProject}
+              variant="solid"
+              color="primary"
+              className="space-x-1"
+              disabled={
+                disableCreation || !!process.env.NEXT_PUBLIC_MAINTENANCE_MODE
+              }
+            >
+              <IconPlusCircle size={18} />
+              <span>Create project</span>
+            </Popover.Button>
+            <Popover.Panel>
+              {isAnonymousUser && (
+                <div>
+                  <Text>
+                    Sorry, you need an email with your account to create a
+                    project. Otherwise, you may lose access to your project.
+                  </Text>
+                  <Text>
+                    You can re-sign in with your email or social media account
+                  </Text>
+                </div>
+              )}
+            </Popover.Panel>
+          </Popover>
         </div>
         {projects?.length ? (
           <div className="flex flex-row">
-            <ul className="flex-1 space-y-6" aria-label="Project list">
+            <ul className="flex-1 space-y-6">
               {projects.map((project) => (
                 <li key={project.id}>
                   <ProjectCard

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,7 @@
   "extends": "@chirpy-dev/tsconfigs/base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "exclude": ["node_modules"],
   "include": ["typings/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
       '@types/react-flatpickr': 3.8.8
+      '@types/testing-library__jest-dom': 5.14.5
       autoprefixer: 10.4.13
       avvvatars-react: 0.4.2
       babel-loader: 8.2.5
@@ -620,6 +621,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
       '@types/react-flatpickr': 3.8.8
+      '@types/testing-library__jest-dom': 5.14.5
       autoprefixer: 10.4.13_postcss@8.4.19
       babel-loader: 8.2.5_ztqwsvkb6z73luspkai6ilstpu
       chromatic: 6.11.4
@@ -15689,7 +15691,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || 18
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || 18
     dependencies:
-      next: 13.0.6_biqbaboplfbrettd7655fr4n2y
+      next: 13.0.6_kzvotn2zipzqwaptii5a7wxu3y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -15712,7 +15714,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 13.0.6_biqbaboplfbrettd7655fr4n2y
+      next: 13.0.6_kzvotn2zipzqwaptii5a7wxu3y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes a dozen of issues:
- Can't post a comment in comment widget preview on home page
- Shouldn't query notification messages in comment widget preview

Added a new feature:
- show popover if user can't create a project, e.g. system maintenance mode, anonymous user or reach maximum project number

<img width="899" alt="image" src="https://user-images.githubusercontent.com/7880675/206723520-11a25544-7df6-4849-b524-4cb12f8ca5f1.png">


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):


## Checklist

- [ ] Unit tests and integration tests passed
- [ ] No reduction in test coverage
- [ ] Documentation is up to date (if appropriate)
- [ ] Related issues linked using `fixes #number`
